### PR TITLE
Allow read/write capabilities for mongolizer

### DIFF
--- a/mongo/replicated_auth_boostrap/init.sh
+++ b/mongo/replicated_auth_boostrap/init.sh
@@ -79,7 +79,7 @@ mongo --quiet --eval "
 db.getSiblingDB(\"admin\").createUser({
     user: \"${MONGOLIZER_USERNAME:?}\",
     pwd: \"${MONGOLIZER_PASSWORD:?}\",
-    roles: [{ role: \"backup\", db:\"admin\"}]
+    roles: [\"readWriteAnyDatabase\"]
 });"
 
 mongo --quiet --eval "


### PR DESCRIPTION
The mongolizer app has the capability to restore a collection from a previous backup, which means it will remove the all the data from that collection and restore it from the specified backup. Unfortunately, the `backup` role does not have delete rights nor does the `restore` one, so we will need the `readWriteAnyDatabase` role for this user.