### PR TITLE
feat: upgrades init containers to v4

### DIFF
--- a/mongo/auth-bootstrap/Dockerfile
+++ b/mongo/auth-bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-from mongo:3.4
+from mongo:4.0
 
 ENV ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
 ENV ADMIN_PASSWORD=${ADMIN_PASSWORD}

--- a/mongo/bootstrap/Dockerfile
+++ b/mongo/bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-from mongo:3.4
+from mongo:4.0
 
 env USERNAME=${USERNAME:-testuser}
 env PASSWORD=${PASSWORD:-testpassword}

--- a/mongo/config_bootstrap/Dockerfile
+++ b/mongo/config_bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-from mongo:3.4
+from mongo:4.0
 
 env ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
 env ADMIN_PASSWORD=${ADMIN_PASSWORD}

--- a/mongo/ensure-cluster-user/Dockerfile
+++ b/mongo/ensure-cluster-user/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:3.4
+FROM mongo:4.0
 
 ENV SERVICE_NAME=${SERVICE_NAME:-mongo} \
     REPLICA_SET=${REPLICA_SET} \

--- a/mongo/ensure-standalone-user/Dockerfile
+++ b/mongo/ensure-standalone-user/Dockerfile
@@ -1,4 +1,4 @@
-from mongo:3.4
+from mongo:4.0
 
 env USERNAME=${USERNAME:-test_role_username} \
 	     PASSWORD=${PASSWORD:-test_role_password} \

--- a/mongo/index/Dockerfile
+++ b/mongo/index/Dockerfile
@@ -1,4 +1,4 @@
-from mongo:3.4
+from mongo:4.0
 
 env USERNAME=MONGO_HOST=${MONGO_HOST:-localhost} \
 	     MONGO_PORT=${MONGO_PORT:-27017} \

--- a/mongo/replicated_auth_boostrap/Dockerfile
+++ b/mongo/replicated_auth_boostrap/Dockerfile
@@ -1,4 +1,4 @@
-from mongo:3.4
+from mongo:4.0
 
 env ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
 env ADMIN_PASSWORD=${ADMIN_PASSWORD}

--- a/mongo/replicated_bootstrap/Dockerfile
+++ b/mongo/replicated_bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-from mongo:3.4
+from mongo:4.0
 
 env REPLICATION_NODES=${REPLICATION_NODES}
 env REPL_SET=${REPL_SET}

--- a/mongo/shard_bootstrap/Dockerfile
+++ b/mongo/shard_bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-from mongo:3.4
+from mongo:4.0
 
 env ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
 env ADMIN_PASSWORD=${ADMIN_PASSWORD}


### PR DESCRIPTION
upgrades the init containers to v4.0, without this you will be unable to create a version 4 cluster due to the feature compatibility version.

***Note*** 
This does mean that everyone will need to run mongo 4 for new deployments, it also means that you will no longer be able to use the current mongolizer.

The mongolizer replacement can be found here https://github.com/utilitywarehouse/mongo-burs which also backs up indices (the current mongolizer does not), it works for both AWS and GCP buckets. The image also has the ability to restore, which should be done as the admin user and not the mongolizer user

Upgrading to mongo v4 is pretty straight forward, docs can be found here https://github.com/utilitywarehouse/telecom/wiki/mongodb_upgrading